### PR TITLE
Syntax error fixes

### DIFF
--- a/src/g2aero/Grassmann.py
+++ b/src/g2aero/Grassmann.py
@@ -57,7 +57,7 @@ def exp(t, X, direction):
 
     :param t: scalar > 0, how far in given direction to move (if t=0, exp(X, log_map) = X)
     :param X: (n_landmarks, 2) array defining starting point of geodesic on Grassmann
-    :param direction: (n_landmarks, 2) array defining direction in tangent space (tangent vector \Delta)
+    :param direction: (n_landmarks, 2) array defining direction in tangent space (tangent vector \\Delta)
     :return: (n_landmarks, 2) array defining end point on Grassmann
     """
     U, S, Vh = np.linalg.svd(direction, full_matrices=False)
@@ -70,11 +70,11 @@ def log(X, Y):
     """Logarithmic mapping (inverse mapping of exponential map). Algorithm 11 (Zimmermann, 2019)
     
     Calculate logarithmic map log_X(Y) (inverse mapping of exponential map).
-    Calculates direction(tangent vector \Delta) from X to Y in tangent subspace.
+    Calculates direction(tangent vector \\Delta) from X to Y in tangent subspace.
 
     :param X: (n_landmarks, 2) array defining start point of geodesic on Grassmann
     :param Y: (n_landmarks, 2) array defining end point of geodesic on Grassmann
-    :return: (n_landmarks, 2) array defining direction in tangent space (tangent vector \Delta)
+    :return: (n_landmarks, 2) array defining direction in tangent space (tangent vector \\Delta)
     """
     X, Y = np.asarray(X), np.asarray(Y)
     # Procrutes match

--- a/src/g2aero/Grassmann.py
+++ b/src/g2aero/Grassmann.py
@@ -57,7 +57,7 @@ def exp(t, X, direction):
 
     :param t: scalar > 0, how far in given direction to move (if t=0, exp(X, log_map) = X)
     :param X: (n_landmarks, 2) array defining starting point of geodesic on Grassmann
-    :param direction: (n_landmarks, 2) array defining direction in tangent space (tangent vector \\Delta)
+    :param direction: (n_landmarks, 2) array defining direction in tangent space (tangent vector :math:`\Delta`)
     :return: (n_landmarks, 2) array defining end point on Grassmann
     """
     U, S, Vh = np.linalg.svd(direction, full_matrices=False)
@@ -70,11 +70,11 @@ def log(X, Y):
     """Logarithmic mapping (inverse mapping of exponential map). Algorithm 11 (Zimmermann, 2019)
     
     Calculate logarithmic map log_X(Y) (inverse mapping of exponential map).
-    Calculates direction(tangent vector \\Delta) from X to Y in tangent subspace.
+    Calculates direction(tangent vector :math:`\Delta`) from X to Y in tangent subspace.
 
     :param X: (n_landmarks, 2) array defining start point of geodesic on Grassmann
     :param Y: (n_landmarks, 2) array defining end point of geodesic on Grassmann
-    :return: (n_landmarks, 2) array defining direction in tangent space (tangent vector \\Delta)
+    :return: (n_landmarks, 2) array defining direction in tangent space (tangent vector :math:`\Delta`)
     """
     X, Y = np.asarray(X), np.asarray(Y)
     # Procrutes match

--- a/src/g2aero/SPD.py
+++ b/src/g2aero/SPD.py
@@ -103,8 +103,8 @@ def exp(t, P, S):
     """SPD Exponential. (Fletcher, P. T., & Joshi, S. 2004)
 
     :param t: scalar > 0, how far in given direction to move (if t=0, exp(P, log_map) = P)
-    :param P: (2, 2) array = starting point \in S_++^2
-    :param S: (2, 2) array = direction in tangent space \in T_P S_++^2
+    :param P: (2, 2) array = starting point \\in S_++^2
+    :param S: (2, 2) array = direction in tangent space \\in T_P S_++^2
     :return: (2, 2) array  = end point 
     """
     Lambda, u = np.linalg.eig(P)
@@ -118,11 +118,11 @@ def exp(t, P, S):
 def log(P, D):
     """SPD Logarithmic mapping (inverse mapping of exponential map). (Fletcher, P. T., & Joshi, S. 2004)
 
-    Calculates direction S (tangent vector \Delta) from P to D in tangent subspace.
+    Calculates direction S (tangent vector \\Delta) from P to D in tangent subspace.
 
-    :param P: (2, 2) array = start point  \in S_++^2
-    :param D: (2, 2) array = end point \in S_++^2
-    :return: (2, 2) array = direction in tangent space (tangent vector \Delta) \in T_P S_++^2
+    :param P: (2, 2) array = start point  \\in S_++^2
+    :param D: (2, 2) array = end point \\in S_++^2
+    :return: (2, 2) array = direction in tangent space (tangent vector \\Delta) \\in T_P S_++^2
     """
     Lambda, u = np.linalg.eig(P)
     g = u * np.sqrt(Lambda)  # g = u @ np.diag(np.sqrt(Lambda))

--- a/src/g2aero/SPD.py
+++ b/src/g2aero/SPD.py
@@ -103,8 +103,8 @@ def exp(t, P, S):
     """SPD Exponential. (Fletcher, P. T., & Joshi, S. 2004)
 
     :param t: scalar > 0, how far in given direction to move (if t=0, exp(P, log_map) = P)
-    :param P: (2, 2) array = starting point \\in S_++^2
-    :param S: (2, 2) array = direction in tangent space \\in T_P S_++^2
+    :param P: (2, 2) array = starting point :math:`\in` S_++^2
+    :param S: (2, 2) array = direction in tangent space :math:`\in` T_P S_++^2
     :return: (2, 2) array  = end point 
     """
     Lambda, u = np.linalg.eig(P)
@@ -118,11 +118,11 @@ def exp(t, P, S):
 def log(P, D):
     """SPD Logarithmic mapping (inverse mapping of exponential map). (Fletcher, P. T., & Joshi, S. 2004)
 
-    Calculates direction S (tangent vector \\Delta) from P to D in tangent subspace.
+    Calculates direction S (tangent vector :math:`\Delta`) from P to D in tangent subspace.
 
-    :param P: (2, 2) array = start point  \\in S_++^2
-    :param D: (2, 2) array = end point \\in S_++^2
-    :return: (2, 2) array = direction in tangent space (tangent vector \\Delta) \\in T_P S_++^2
+    :param P: (2, 2) array = start point :math:`\in` S_++^2
+    :param D: (2, 2) array = end point :math:`\in` S_++^2
+    :return: (2, 2) array = direction in tangent space (tangent vector :math:`\Delta`) :math:`\in` T_P S_++^2
     """
     Lambda, u = np.linalg.eig(P)
     g = u * np.sqrt(Lambda)  # g = u @ np.diag(np.sqrt(Lambda))


### PR DESCRIPTION
I am not sure this is the actual way you would like to fix these but without them, I get:
```
/Users/mhenryde/ds4mems/airfoil-shapes/.venv/lib/python3.12/site-packages/g2aero/Grassmann.py:56: SyntaxWarning: invalid escape sequence '\D'
  """Exponential mapping (Grassmannian geodesic).
/Users/mhenryde/ds4mems/airfoil-shapes/.venv/lib/python3.12/site-packages/g2aero/Grassmann.py:70: SyntaxWarning: invalid escape sequence '\D'
  """Logarithmic mapping (inverse mapping of exponential map). Algorithm 11 (Zimmermann, 2019)
/Users/mhenryde/ds4mems/airfoil-shapes/.venv/lib/python3.12/site-packages/g2aero/SPD.py:103: SyntaxWarning: invalid escape sequence '\i'
  """SPD Exponential. (Fletcher, P. T., & Joshi, S. 2004)
/Users/mhenryde/ds4mems/airfoil-shapes/.venv/lib/python3.12/site-packages/g2aero/SPD.py:119: SyntaxWarning: invalid escape sequence '\D'
  """SPD Logarithmic mapping (inverse mapping of exponential map). (Fletcher, P. T., & Joshi, S. 2004)
  ```