### PR TITLE
Add Torch autodiff support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML
 numpy
 scipy
 setuptools
+torch

--- a/src/g2aero/Grassmann.py
+++ b/src/g2aero/Grassmann.py
@@ -1,5 +1,6 @@
 # Intrinsic maps and routines for the Grassmannian
 import numpy as np
+import torch
 
 
 def procrustes(X, Y):
@@ -60,9 +61,19 @@ def exp(t, X, direction):
     :param direction: (n_landmarks, 2) array defining direction in tangent space (tangent vector \Delta)
     :return: (n_landmarks, 2) array defining end point on Grassmann
     """
-    U, S, Vh = np.linalg.svd(direction, full_matrices=False)
-    exp_map = np.hstack((X @ Vh.T, U)) @ np.vstack((np.diag(np.cos(t *
-                                                                   S)), np.diag(np.sin(t * S)))) @ Vh
+    if torch.is_tensor(direction) or torch.is_tensor(X):
+        reference = direction if torch.is_tensor(direction) else X
+        direction = torch.as_tensor(direction, dtype=reference.dtype, device=reference.device)
+        X = torch.as_tensor(X, dtype=reference.dtype, device=reference.device)
+        U, S, Vh = torch.linalg.svd(direction, full_matrices=False)
+        exp_map = torch.hstack((X @ Vh.T, U)) @ torch.vstack(
+            (torch.diag(torch.cos(t * S)), torch.diag(torch.sin(t * S)))
+        ) @ Vh
+    else:
+        U, S, Vh = np.linalg.svd(direction, full_matrices=False)
+        exp_map = np.hstack((X @ Vh.T, U)) @ np.vstack(
+            (np.diag(np.cos(t * S)), np.diag(np.sin(t * S)))
+        ) @ Vh
     return exp_map
 
 
@@ -238,7 +249,12 @@ def perturb_gr_shape(Vh, mu, perturbation):
     :param perturbation: (n_modes,) array of amount of perturbations in pga coordinates
     :return: (n_landmarks, 2) array of perturbed element on Grassmann
     """
-    perturbation = np.asarray(perturbation).reshape(1, -1)
+    if torch.is_tensor(perturbation):
+        perturbation = perturbation.reshape(1, -1)
+        Vh = torch.as_tensor(Vh, dtype=perturbation.dtype, device=perturbation.device)
+        mu = torch.as_tensor(mu, dtype=perturbation.dtype, device=perturbation.device)
+    else:
+        perturbation = np.asarray(perturbation).reshape(1, -1)
     n_modes = perturbation.shape[1]
     direction = perturbation@Vh[:n_modes]
     direction = direction.reshape(-1, 2)

--- a/src/g2aero/PGA.py
+++ b/src/g2aero/PGA.py
@@ -3,6 +3,7 @@ from scipy.interpolate import PchipInterpolator
 import g2aero.Grassmann as gr
 from g2aero.utils import check_selfintersect
 import g2aero.SPD as spd
+import torch
 
 
 class Grassmann_PGAspace:
@@ -92,6 +93,9 @@ class Grassmann_PGAspace:
         if original_shape_gr is not None:
             R = gr.procrustes(gr_shape, original_shape_gr)
             gr_shape= gr_shape @ R
+        if torch.is_tensor(gr_shape):
+            M = torch.as_tensor(M, dtype=gr_shape.dtype, device=gr_shape.device)
+            b = torch.as_tensor(b, dtype=gr_shape.dtype, device=gr_shape.device)
         return gr_shape @ M + b
 
     def gr_shapes2PGA(self, shapes_gr):

--- a/tests/test_Grassmann.py
+++ b/tests/test_Grassmann.py
@@ -1,6 +1,7 @@
 import os
 from unittest import TestCase
 from g2aero.Grassmann import *
+import torch
 
 
 class Test(TestCase):
@@ -28,6 +29,14 @@ class Test(TestCase):
         Y1 = exp(1, self.X, self.vector)
         new_vector = log(self.X, Y1)
         np.testing.assert_almost_equal(self.vector, new_vector, decimal=10, err_msg='', verbose=True)
+
+    def test_exp_torch_gradient(self):
+        direction = torch.tensor(self.vector, dtype=torch.float64, requires_grad=True)
+        result = exp(1, self.X, direction)
+        assert torch.is_tensor(result)
+        result.square().sum().backward()
+        assert direction.grad is not None
+        assert torch.all(torch.isfinite(direction.grad))
 
     def test_parallel_translate(self):
         direction = log(self.X, self.Y)
@@ -62,5 +71,4 @@ class Test(TestCase):
         R1 = np.array([[np.cos(np.pi/2), np.sin(np.pi/2)], [- np.sin(np.pi/2), np.cos(np.pi/2)]])
         new_R1 = procrustes(self.Y, self.Y @ R1)
         np.testing.assert_almost_equal(R1, new_R1, decimal=10, err_msg='', verbose=True)
-
 

--- a/tests/test_PGA_space.py
+++ b/tests/test_PGA_space.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import torch
 from unittest import TestCase
 from g2aero.PGA import *
 from g2aero.Grassmann import procrustes
@@ -21,3 +22,23 @@ class Test(TestCase):
         X_new = self.pga.PGA2gr_shape(t)
         X_new = X_new @ procrustes(X_new, self.X)
         np.testing.assert_almost_equal(self.X, X_new, decimal=10, err_msg='', verbose=True)
+
+    def test_PGA2shape_torch_gradient(self):
+        coordinates = torch.linspace(1e-3, 8e-3, 8, dtype=torch.float64, requires_grad=True)
+        shape = self.pga.PGA2shape(coordinates)
+        assert torch.is_tensor(shape)
+        objective = shape[:, 1].sum()
+        objective.backward()
+        assert coordinates.grad is not None
+        assert torch.all(torch.isfinite(coordinates.grad))
+
+        step = 1e-6
+        plus = coordinates.detach().clone()
+        minus = coordinates.detach().clone()
+        plus[0] += step
+        minus[0] -= step
+        finite_difference = (
+            self.pga.PGA2shape(plus)[:, 1].sum()
+            - self.pga.PGA2shape(minus)[:, 1].sum()
+        ) / (2 * step)
+        torch.testing.assert_close(coordinates.grad[0], finite_difference, rtol=1e-5, atol=1e-7)


### PR DESCRIPTION
## Summary

- add Torch autodiff support to Grassmann operations
- preserve differentiability through PGA transformations
- extend the Grassmann and PGA test coverage

## Why

This enables downstream users to differentiate through the geometry and PGA operations with Torch tensors.

## Validation

- `python -m pytest -q`
- 16 tests passed

## Data files

Generated `.npz` data and local notebook LFS conversions are intentionally excluded from this PR.